### PR TITLE
commented out the shift of the grid and added autopivotize to the

### DIFF
--- a/src/service/Configurator_6D.tpp
+++ b/src/service/Configurator_6D.tpp
@@ -73,6 +73,8 @@ void Configurator_6D<SERVICE>::init(CmdArgs const& args) noexcept {
 		if (!h.pivots.empty()) {
 			throw std::logic_error("Auto pivot specified, but explicitly defined pivots available. (File " + args.dofName + ")" );
 		}
+		receptor->auto_pivotize();
+		ligand->auto_pivotize();
 		h.pivots.push_back(receptor->pivot());
 		h.pivots.push_back(ligand->pivot());
 	} else {
@@ -97,8 +99,8 @@ void Configurator_6D<SERVICE>::init(CmdArgs const& args) noexcept {
 
 
 	/* apply grid displacement */
-	auto pivot = h.pivots[0];
-	grid->translate(-make_real3(pivot.x,pivot.y,pivot.z));
+//	auto pivot = h.pivots[0];
+//	grid->translate(-make_real3(pivot.x,pivot.y,pivot.z));
 
 	/* add items to dataMng */
 	std::shared_ptr<DataManager> dataManager = std::make_shared<DataManager>();


### PR DESCRIPTION
configurator.
In my test I found out that this should yield the exact same results as
the original version, if the ligand-pivot is added to the translation
dof which i did in the integration of modes branch