### PR TITLE
AS26 -  small changes to cpu es service, transform_modes.h and Vec3

### DIFF
--- a/src/commons/Vec3.h
+++ b/src/commons/Vec3.h
@@ -177,7 +177,7 @@ public:
 	}
 
 	__host__ __device__
-		double inv() const {
+		Vec3 inv() const {
 		Vec3 inv;
 		inv.x = -x;
 		inv.y = -y;

--- a/src/model/neighborlist_modes.h
+++ b/src/model/neighborlist_modes.h
@@ -12,6 +12,8 @@
 #include "neighborlist.h"
 
 
+namespace as {
+
 /**
  * this is an overloaded Version of the original  NLPotForce function which directly calculates the counteracting forces acting on the receptor.
  */
@@ -202,6 +204,6 @@ void NLPotForce(
 		} // for i
 	}
 }
-
+}//end Namespace as
 
 #endif /* NEIGHBORLIST_MODES_H_ */

--- a/src/model/transform_modes.h
+++ b/src/model/transform_modes.h
@@ -8,8 +8,9 @@
 #ifndef TRANSFORM_MODES_H_
 #define TRANSFORM_MODES_H_
 
-
 #include "transform.h"
+#include "Types_6D_Modes.h"
+
 
  namespace as{
 
@@ -26,10 +27,11 @@ template<typename REAL>
 const DOF_6D_Modes<REAL> invertDOF( DOF_6D_Modes<REAL> ligandDOF)
 {
 	DOF_6D_Modes<REAL> invertedDOF;
-	invertedDOF._6D.ang=receptorDOF.ang;
+	Vec3<REAL> ang(0.0);
+	invertedDOF._6D.ang=ang;
 	invertedDOF._6D.pos=ligandDOF._6D.pos.inv();
 	const RotMat<REAL> rotMat=euler2rotmat(ligandDOF._6D.ang.x, ligandDOF._6D.ang.y, ligandDOF._6D.ang.z).getInv();
-	invertedDOF._6D.pos=rotMat*invertedDOF.pos;
+	invertedDOF._6D.pos=rotMat*invertedDOF._6D.pos;
 return invertedDOF;
 }
 

--- a/src/service/CPUEnergyService6DModes.tpp
+++ b/src/service/CPUEnergyService6DModes.tpp
@@ -19,9 +19,9 @@
 #include "SimParam.h"
 
 
-#include "transform.h"
+#include "transform_modes.h"
 #include "interpolation.h"
-#include "neighborlist.h"
+#include "neighborlist_modes.h"
 #include "reduction_modes.h"
 #include "matrixFunctions.h"
 #include "RotMat.h"
@@ -233,8 +233,7 @@ auto CPUEnergyService6DModes<REAL>::createItemProcessor() -> itemProcessor_t {
 				buffers->h_potLig.getW(),
 				buffers->h_potRec.getX(), // output
 				buffers->h_potRec.getY(),
-				buffers->h_potRec.getZ(),
-				buffers->h_potRec.getW()
+				buffers->h_potRec.getZ()
 			); // OK
 
 ////			// Debug


### PR DESCRIPTION
had to correct minor errors in the following files:
1. Vec3: function vec3::inv() had the wrong return type
2. neighborlist_modes.h namespace as was not defined
3. transform_modes.h: modetype was not included and invertDOF had minor
errors
4. cpu es had wrong includes and used old nl_potforce with energy of
receptor