### PR TITLE
As 30 boost compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,13 @@ INCLUDES = $(foreach d, $(SOURCE_FOLDERS), -I$d)
 LDFLAGS =  #-L...
 LIBS =  -lpthread -lrt $(LIBS_TEST) -lboost_program_options -lgfortran -lboost_coroutine -lboost_context -lboost_system
 
+# for testing with different boost lib versions. should be disabled by default.
+ifeq (1, 0)
+#	INCLUDES += -I/home/uwe/dev/boost_1_55_0
+#	LDFLAGS += -L/home/uwe/dev/boost_1_55_0/stage/lib
+	INCLUDES += -I/home/uwe/dev/boost_1_54_0
+	LDFLAGS += -L/home/uwe/dev/boost_1_54_0/stage/lib
+endif
 
 ifeq ($(CUDA), ON)
 	OFLAGS += -DCUDA

--- a/src/apps/em/BFGSSolver.cpp
+++ b/src/apps/em/BFGSSolver.cpp
@@ -34,7 +34,7 @@ int sign(T val) {
 	return (T(0) < val) - (val < T(0));
 }
 
-void as::BFGSSolver::run(coro_t::caller_type& ca) {
+void as::BFGSSolver::run(push_type& ca) {
 
 	/* Algorithm 6.1, J. Nocedal, S. J. Wright, Numerical Optimization (2nd Edition), page 140 */
 	Vector x_curr = getState();
@@ -166,7 +166,7 @@ inline double cubic_interpolate(const double& alpha_curr, const double& alpha_la
 }
 
 
-inline double as::BFGSSolver::zoom(coro_t::caller_type& ca, const Vector& x0, const Vector& p,
+inline double as::BFGSSolver::zoom(push_type& ca, const Vector& x0, const Vector& p,
 		const ObjGrad& objGrad0, const double& phi0_dash, const double& min_alpha,
 		double& alpha_lo, double& alpha_hi,
 		ObjGrad& objGrad_lo, ObjGrad& objGrad_hi,
@@ -249,7 +249,7 @@ inline double as::BFGSSolver::zoom(coro_t::caller_type& ca, const Vector& x0, co
 
 } // namespace
 
-double as::BFGSSolver::linesearch_WolfeRule(coro_t::caller_type& ca, const Vector& x0, const ObjGrad& objGrad0, const Vector& p,
+double as::BFGSSolver::linesearch_WolfeRule(push_type& ca, const Vector& x0, const ObjGrad& objGrad0, const Vector& p,
 		const double& dObj,
 		/*OUT:*/ Vector& x_next, ObjGrad& objGrad_next)
 {

--- a/src/apps/em/BFGSSolver.h
+++ b/src/apps/em/BFGSSolver.h
@@ -108,13 +108,13 @@ public:
 
 private:
 
-	void run(coro_t::caller_type& ca) override;
+	void run(push_type& ca) override;
 
-	double linesearch_WolfeRule(coro_t::caller_type& ca, const Vector& x0, const ObjGrad& objGrad0, const Vector& p,
+	double linesearch_WolfeRule(push_type& ca, const Vector& x0, const ObjGrad& objGrad0, const Vector& p,
 			const double& dObj,
 			/*OUT:*/ Vector& x_next, ObjGrad& objGrad_next);
 
-	double zoom(coro_t::caller_type& ca, const Vector& x0, const Vector& p,
+	double zoom(push_type& ca, const Vector& x0, const Vector& p,
 		const ObjGrad& objGrad0, const double& phi0_dash, const double& min_alpha,
 		double& alpha_lo, double& alpha_hi,
 		ObjGrad& objGrad_lo, ObjGrad& objGrad_hi,

--- a/src/apps/em/LBFGS_B_Solver.cpp
+++ b/src/apps/em/LBFGS_B_Solver.cpp
@@ -144,7 +144,7 @@ int lbfgsb_run(LBFGS_B_WorkingStruct& opt, double* x, double* f, double* g) {
 	}
 }
 
-void as::LBFGS_B_Solver::run(coro_t::caller_type& energyAndGradients) {
+void as::LBFGS_B_Solver::run(push_type& energyAndGradients) {
 	// dimension of problem
 	int n = state.rows();
 

--- a/src/apps/em/LBFGS_B_Solver.h
+++ b/src/apps/em/LBFGS_B_Solver.h
@@ -70,7 +70,7 @@ public:
 
 private:
 
-	void run(coro_t::caller_type& ca) override;
+	void run(push_type& ca) override;
 
 	/* solver options */
 	static Options settings;

--- a/src/apps/em/SolverBase.cpp
+++ b/src/apps/em/SolverBase.cpp
@@ -27,7 +27,7 @@
 
 void as::SolverBase::start() {
 	assert(state.rows() > 0);
-	coro =  new coro_t(std::bind(&SolverBase::run, this, std::placeholders::_1));
+	coro =  new pull_type(std::bind(&SolverBase::run, this, std::placeholders::_1));
 
 
 }

--- a/src/apps/em/SolverBase.h
+++ b/src/apps/em/SolverBase.h
@@ -22,6 +22,7 @@
 #define SOLVERBASE_H_
 
 #include <boost/coroutine/all.hpp>
+#include <boost/version.hpp>
 #include <Eigen/Core>
 #include <cassert>
 
@@ -29,7 +30,22 @@
 
 namespace as {
 
+
+#if BOOST_VERSION <= 105400
 using coro_t = boost::coroutines::coroutine<void(void)>;
+using pull_type = coro_t;
+using push_type = coro_t::caller_type;
+#elif BOOST_VERSION == 105500
+using coro_t = boost::coroutines::coroutine<void>;
+using pull_type = coro_t::pull_type;
+using push_type = coro_t::push_type;
+#elif BOOST_VERSION >= 105600
+using coro_t = boost::coroutines::asymmetric_coroutine<void>;
+using pull_type = coro_t::pull_type;
+using push_type = coro_t::push_type;
+#endif
+
+//static_assert(false, BOOST_LIB_VERSION );
 
 struct Statistic {
 	virtual Statistic* getCopy() const = 0;
@@ -96,7 +112,7 @@ public:
 
 protected:
 
-	virtual void run(coro_t::caller_type& ca) = 0;
+	virtual void run(push_type& ca) = 0;
 
 	virtual Statistic* internal_getStats() = 0;
 
@@ -104,7 +120,7 @@ protected:
 	Vector state; // dof
 	ObjGrad objective; // energy
 
-	coro_t* coro;
+	pull_type* coro;
 
 	static bool stats;
 

--- a/src/apps/em/VA13Solver.cpp
+++ b/src/apps/em/VA13Solver.cpp
@@ -31,7 +31,7 @@ extern "C" void minfor_(void* FortranSmuggler_ptr, int const& maxFunEval,
 
 namespace as {
 
-void VA13Solver::run(coro_t::caller_type& ca) {
+void VA13Solver::run(push_type& ca) {
 	/* Create Smuggler */
 	VA13Solver::FortranSmuggler smuggler(ca, state, objective);
 

--- a/src/apps/em/VA13Solver.h
+++ b/src/apps/em/VA13Solver.h
@@ -71,7 +71,7 @@ public:
 
 	class FortranSmuggler {
 	public:
-		FortranSmuggler (coro_t& _coro, Vector& _state, ObjGrad& _objective):
+		FortranSmuggler (push_type& _coro, Vector& _state, ObjGrad& _objective):
 			coro(_coro),
 			state(_state),
 			objective(_objective)
@@ -79,10 +79,12 @@ public:
 
 		Vector& state_ref() { return state; }
 		ObjGrad& objective_ref() { return objective; }
-		void call_coro() { coro(); };
+		void call_coro() {
+			coro();
+		};
 
 	private:
-		coro_t& coro;
+		push_type& coro;
 		Vector& state;
 		ObjGrad& objective;
 	};
@@ -90,7 +92,7 @@ public:
 
 private:
 
-	void run(coro_t::caller_type& ca) override;
+	void run(push_type& ca) override;
 
 	/* solver options */
 	static Options settings;


### PR DESCRIPTION
using a native boost setup of Ubuntu 16.04 with boost version 1.58 didn't compile because of interface changes of boost::coroutine. The code is now compatible with both the older and the new interface.